### PR TITLE
Add a way to initialize DieselMiddleware with an existing db pool

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -35,6 +35,10 @@ impl<T> DieselMiddleware<T> where
 
         Ok(DieselMiddleware { pool: Arc::new(pool) })
     }
+
+    pub fn from_pool(pool: Pool<ConnectionManager<T>>) -> DieselMiddleware<T> {
+        DieselMiddleware { pool: Arc::new(pool) }
+    }
 }
 
 impl<T> Key for DieselMiddleware<T> where


### PR DESCRIPTION
I have an application that shares a DB pool with a few threads, only one of which is the web application, so I wanted to be able to create the pool separately from the `nickel` app, and pass the pool to the `nickel` app.
