### PR TITLE
Update diesel dependency to 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 nickel = "0.8.0"
 postgres = "0.11.7"
 r2d2 = "0.7.0"
-r2d2-diesel = "0.6.0"
+r2d2-diesel = "0.7"
 plugin = "0.2.6"
 typemap = "0.3.3"
 
@@ -20,6 +20,6 @@ typemap = "0.3.3"
 dotenv = "0.8.0"
 
 [dependencies.diesel]
-version = "0.6.0"
+version = "0.7"
 default-features = false
 features = ["postgres", "sqlite"]


### PR DESCRIPTION
Please release a nickel-diesel where the diesel (and r2d2-diesel) dependency is updated to 0.7.
