### PR TITLE
Update diesel to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ readme = "README.md"
 
 [dependencies]
 nickel = "0.9.0"
-postgres = "0.11.7"
-r2d2 = "0.7.0"
-r2d2-diesel = "0.8"
+postgres = "^0.13"
+r2d2 = "^0.7"
+r2d2-diesel = "^0.9"
 plugin = "0.2.6"
 typemap = "0.3.3"
 
 [dev-dependencies]
-dotenv = "0.8.0"
+dotenv = "^0.8"
 
 [dependencies.diesel]
-version = "0.8"
+version = "^0.9"
 default-features = false
 features = ["postgres", "sqlite"]


### PR DESCRIPTION
Can we get a release of nickel-diesel that works with diesel version 0.9?

This update seems to work for me.

Including related updates of rd2d-diesel (and why not postgres).